### PR TITLE
Update jugglingdb-cozy-adapter for Node 4 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 { "name": "todos"
-, "version": "0.5.0"
+, "version": "0.5.1"
 , "description": "Cozy Todos is a simple task management application that helps you to focus by not wasting time in your todo-lists. Adding tasks is easy as typing in a text editor, but UI is explicit as it should be in a web app."
 , "engines": ["node >= 0.8.0"]
 , "main": "server.coffee"
@@ -12,7 +12,7 @@
   , "mime":             "= 1.2.7"
   , "qs":               "= 0.5.0"
   , "jugglingdb":       "= 0.2.0-23"
-  , "jugglingdb-cozy-adapter": "0.3.3"
+  , "jugglingdb-cozy-adapter": "0.4.15"
   , "async":            "= 0.1.22"
   , "cozy-realtime-adapter":"= 0.11.0"
   }


### PR DESCRIPTION
I know that this application is deprecated, but some users still use it.
The application is broken with Node 4, so users won't be able to access the todos after their instance has been migrated.
This patch should fix it (crossing fingers)

/cc @jsilvestre
